### PR TITLE
Mark Antigravity plan as merged

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -15,7 +15,7 @@ undocumented vendor endpoint sight unseen.
 |---|---|---|---|---|---|
 | 001 | Add a maintainable Electron companion without replacing native macOS | P1 | L | — | Superseded by the repository split |
 | 002 | Add a Cursor usage provider to the native macOS app | P2 | M | — | DONE |
-| 003 | Add an Antigravity usage provider to the native macOS app | P2 | M | — | Draft PR [#5](https://github.com/yurirxmos/metria/pull/5) |
+| 003 | Add an Antigravity usage provider to the native macOS app | P2 | M | — | Merged PR [#6](https://github.com/yurirxmos/metria/pull/6) |
 
 ## Plans that moved with their app
 


### PR DESCRIPTION
Update the plan index after PR #6 merged the Antigravity provider.

This follow-up also records Pedro Farath as a co-author for the delivered contribution.