### PR TITLE
Add sound alerts and native notifications for usage thresholds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,8 @@ let package = Package(
                  "apps/macos-native/Sources/Metria/Providers/ProviderKind+Presentation.swift",
                   "apps/macos-native/Sources/Metria/Providers/ProviderRegistry.swift",
                  "apps/macos-native/Sources/Metria/Updater.swift",
-                 "apps/macos-native/Sources/Metria/OnboardingView.swift"
+                 "apps/macos-native/Sources/Metria/OnboardingView.swift",
+                 "apps/macos-native/Sources/Metria/UsageSoundAlerter.swift"
              ],
               resources: [
                   .process("apps/macos-native/Sources/Metria/Localizable.xcstrings"),

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,8 @@ let package = Package(
                   "apps/macos-native/Sources/Metria/Providers/ProviderRegistry.swift",
                  "apps/macos-native/Sources/Metria/Updater.swift",
                  "apps/macos-native/Sources/Metria/OnboardingView.swift",
+                 "apps/macos-native/Sources/Metria/ThresholdCrossingTracker.swift",
+                 "apps/macos-native/Sources/Metria/UsageNotifier.swift",
                  "apps/macos-native/Sources/Metria/UsageSoundAlerter.swift"
              ],
               resources: [

--- a/apps/macos-native/Metria.xcodeproj/project.pbxproj
+++ b/apps/macos-native/Metria.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0F9FCD0AAA8D78AACD6FA6FA /* CursorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329ED075E7D446A1AB88C85C /* CursorProvider.swift */; };
 		1F928336732F72EF903CE215 /* LocalPWAServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942FF095F80398F2F48468E8 /* LocalPWAServer.swift */; };
 		31F56B15827398A3510322E7 /* CodexProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D7C2E17F5F19EAF6C4C74B2 /* CodexProvider.swift */; };
+		3C228112E1DD9D0322EED9BF /* ThresholdCrossingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3A8A8B544FCF7114BE7F7C /* ThresholdCrossingTracker.swift */; };
+		3F11A37FF80A223BC6C19AD6 /* UsageNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A5B69EBF050D0E668B5D8D /* UsageNotifier.swift */; };
 		46A2C87091DB2E55D1B82616 /* MetriaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC404DE64C320E52402D468 /* MetriaApp.swift */; };
 		4721758378AC7CB6DCE97443 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EF981CF3ECD2D27A2B2730B3 /* Sparkle */; };
 		52564D3CB2D6251DD5733657 /* PairingSecret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B8670774860D40198385E3 /* PairingSecret.swift */; };
@@ -61,6 +63,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0C3A8A8B544FCF7114BE7F7C /* ThresholdCrossingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThresholdCrossingTracker.swift; sourceTree = "<group>"; };
 		0D7C2E17F5F19EAF6C4C74B2 /* CodexProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexProvider.swift; sourceTree = "<group>"; };
 		17B8670774860D40198385E3 /* PairingSecret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingSecret.swift; sourceTree = "<group>"; };
 		18B16A90CF8351DF99C63A8A /* LocalNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetwork.swift; sourceTree = "<group>"; };
@@ -85,6 +88,7 @@
 		B5CA5CE06369AFD9039949DE /* BIP39Wordlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BIP39Wordlist.swift; sourceTree = "<group>"; };
 		C8C81534D399ED080DD3983A /* UsageSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSnapshot.swift; sourceTree = "<group>"; };
 		D588191EB0695B9A4FC447E9 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		E4A5B69EBF050D0E668B5D8D /* UsageNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageNotifier.swift; sourceTree = "<group>"; };
 		EB5708106721FFBC18754EDD /* ProviderActivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderActivityMonitor.swift; sourceTree = "<group>"; };
 		FF582539BF3108580AC1F4FC /* ClaudeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -112,7 +116,9 @@
 				97692A6C8502A27D4FA476F0 /* MetriaResources.swift */,
 				5F76937A0473449017F3EB57 /* OnboardingView.swift */,
 				EB5708106721FFBC18754EDD /* ProviderActivityMonitor.swift */,
+				0C3A8A8B544FCF7114BE7F7C /* ThresholdCrossingTracker.swift */,
 				36216E6ACB911FA08CA36234 /* Updater.swift */,
+				E4A5B69EBF050D0E668B5D8D /* UsageNotifier.swift */,
 				28A2DCB6549B42AB4A6EBCF0 /* UsageSoundAlerter.swift */,
 				5B52A35A5B1800D8DF53A0E9 /* Providers */,
 			);
@@ -315,7 +321,9 @@
 				577F4D95C96F959AA5487127 /* ProviderError.swift in Sources */,
 				9CC880BFC528518A30EFE40A /* ProviderKind+Presentation.swift in Sources */,
 				9401FE6A4D61FC25C4CADA12 /* ProviderRegistry.swift in Sources */,
+				3C228112E1DD9D0322EED9BF /* ThresholdCrossingTracker.swift in Sources */,
 				636C3963D32BD250319A58EF /* Updater.swift in Sources */,
+				3F11A37FF80A223BC6C19AD6 /* UsageNotifier.swift in Sources */,
 				C32F260FF0C2A61FE2F5538B /* UsageSoundAlerter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/macos-native/Metria.xcodeproj/project.pbxproj
+++ b/apps/macos-native/Metria.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		B0D16525171231FFE5C69C84 /* OpenCodeGoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A30C52B2A951130A87634 /* OpenCodeGoProvider.swift */; };
 		BCAAA4FF3E584906BD4F3006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F76937A0473449017F3EB57 /* OnboardingView.swift */; };
 		BD14854124859D3F61FFB61D /* AntigravityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358AA6325C40633CC548F9A3 /* AntigravityProvider.swift */; };
+		C32F260FF0C2A61FE2F5538B /* UsageSoundAlerter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A2DCB6549B42AB4A6EBCF0 /* UsageSoundAlerter.swift */; };
 		C60A0D354E8CDD43466B3457 /* CursorStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144FE93ADD1A194EEA0D854 /* CursorStateStore.swift */; };
 		E87CBB5215F9C3C201D860CE /* UsageSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C81534D399ED080DD3983A /* UsageSnapshot.swift */; };
 		EF5641DDF417468BFB615AAD /* ClaudeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF582539BF3108580AC1F4FC /* ClaudeProvider.swift */; };
@@ -64,6 +65,7 @@
 		17B8670774860D40198385E3 /* PairingSecret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingSecret.swift; sourceTree = "<group>"; };
 		18B16A90CF8351DF99C63A8A /* LocalNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetwork.swift; sourceTree = "<group>"; };
 		2144FE93ADD1A194EEA0D854 /* CursorStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorStateStore.swift; sourceTree = "<group>"; };
+		28A2DCB6549B42AB4A6EBCF0 /* UsageSoundAlerter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSoundAlerter.swift; sourceTree = "<group>"; };
 		329ED075E7D446A1AB88C85C /* CursorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorProvider.swift; sourceTree = "<group>"; };
 		358AA6325C40633CC548F9A3 /* AntigravityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntigravityProvider.swift; sourceTree = "<group>"; };
 		36216E6ACB911FA08CA36234 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				5F76937A0473449017F3EB57 /* OnboardingView.swift */,
 				EB5708106721FFBC18754EDD /* ProviderActivityMonitor.swift */,
 				36216E6ACB911FA08CA36234 /* Updater.swift */,
+				28A2DCB6549B42AB4A6EBCF0 /* UsageSoundAlerter.swift */,
 				5B52A35A5B1800D8DF53A0E9 /* Providers */,
 			);
 			path = Metria;
@@ -313,6 +316,7 @@
 				9CC880BFC528518A30EFE40A /* ProviderKind+Presentation.swift in Sources */,
 				9401FE6A4D61FC25C4CADA12 /* ProviderRegistry.swift in Sources */,
 				636C3963D32BD250319A58EF /* Updater.swift in Sources */,
+				C32F260FF0C2A61FE2F5538B /* UsageSoundAlerter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/macos-native/Sources/Metria/MetriaApp.swift
+++ b/apps/macos-native/Sources/Metria/MetriaApp.swift
@@ -6,6 +6,7 @@ import Foundation
 import MetriaCore
 import ServiceManagement
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Stores the pairing master secret in the macOS Keychain. The secret never leaves the
 /// Mac in plaintext: the PWA only ever receives it via the QR code or 12-word phrase,
@@ -1684,6 +1685,12 @@ struct SettingsView: View {
     let onChangeMenuBarAlertColors: (Bool) -> Void
     @AppStorage("showMenuBarProviderNames") private var showMenuBarProviderNames = true
     let onChangeMenuBarProviderNames: (Bool) -> Void
+    @AppStorage("soundAlertsEnabled") private var soundAlertsEnabled = false
+    @AppStorage("soundAlertCautionEnabled") private var soundAlertCautionEnabled = true
+    @AppStorage("soundAlertWarningEnabled") private var soundAlertWarningEnabled = true
+    @AppStorage("soundAlertCriticalEnabled") private var soundAlertCriticalEnabled = true
+    @AppStorage("soundAlertName") private var soundAlertName = "Glass"
+    @AppStorage("soundAlertVolume") private var soundAlertVolume = 1.0
     @State private var cautionThreshold: Int
     @State private var warningThreshold: Int
     @State private var criticalThreshold: Int
@@ -2036,6 +2043,14 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Sound alerts") {
+                Toggle("Play sound when crossing thresholds", isOn: $soundAlertsEnabled)
+                soundAlertControls
+                    .disabled(!soundAlertsEnabled)
+                Text("Plays once each time a provider crosses one of the thresholds above.")
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Monitor") {
                 Picker(
                     "Monitor", selection: Binding(get: { notchScreenID }, set: onSelectNotchScreen)
@@ -2145,6 +2160,67 @@ struct SettingsView: View {
                 warningColor: NSColor(warningColor),
                 criticalColor: NSColor(criticalColor)
             ))
+    }
+
+    private var soundAlertControls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+                soundLevelControl(label: String(localized: "Caution"), isOn: $soundAlertCautionEnabled)
+                soundLevelControl(label: String(localized: "Warning"), isOn: $soundAlertWarningEnabled)
+                soundLevelControl(label: String(localized: "Critical"), isOn: $soundAlertCriticalEnabled)
+            }
+            Picker(
+                "Sound",
+                selection: Binding(
+                    get: { soundAlertName },
+                    set: { newValue in
+                        guard newValue == UsageSoundAlerter.customName else {
+                            soundAlertName = newValue
+                            return
+                        }
+                        pickCustomSound()
+                    }
+                )
+            ) {
+                ForEach(UsageSoundAlerter.systemSoundNames, id: \.self) { name in
+                    Text(name).tag(name)
+                }
+                Text("Custom…").tag(UsageSoundAlerter.customName)
+            }
+            HStack {
+                Slider(value: $soundAlertVolume, in: 0...1)
+                Text("\(Int((soundAlertVolume * 100).rounded()))%")
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .frame(width: 42, alignment: .trailing)
+            }
+            Button("Test") { UsageSoundAlerter.playTestSound() }
+        }
+    }
+
+    private func soundLevelControl(label: String, isOn: Binding<Bool>) -> some View {
+        GridRow {
+            Text(label)
+            Toggle("\(label) sound", isOn: isOn)
+                .labelsHidden()
+        }
+    }
+
+    /// Opens a file picker and copies the chosen audio file into Application Support as the
+    /// custom alert sound. Canceling leaves the current selection untouched.
+    private func pickCustomSound() {
+        try? FileManager.default.createDirectory(
+            at: UsageSoundAlerter.customSoundDirectory, withIntermediateDirectories: true)
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.audio]
+        panel.directoryURL = UsageSoundAlerter.customSoundDirectory
+        guard panel.runModal() == .OK, let url = panel.url,
+            UsageSoundAlerter.importCustomSound(from: url)
+        else { return }
+        soundAlertName = UsageSoundAlerter.customName
     }
 
     /// A small colored status dot shown right after the provider name: green when connected
@@ -2413,7 +2489,7 @@ extension NSMenu {
     }
 }
 
-@MainActor final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+@MainActor final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWindowDelegate {
     let store = UsageStore(providers: ProviderRegistry.makeProviders())
     var statusItem: NSStatusItem!
     var popover: NSPopover!
@@ -2427,6 +2503,7 @@ extension NSMenu {
     let pairing = PairingManager()
     private let updater = AppUpdater()
     private let localPWAServer = LocalPWAServer()
+    let soundAlerter = UsageSoundAlerter()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         migrateDisplayModeIfNeeded()
@@ -2447,6 +2524,7 @@ extension NSMenu {
         observation = store.$providers.sink { [weak self] providers in
             self?.updateStatusItem(providers)
             guard let self else { return }
+            self.soundAlerter.process(providers)
             self.ntfyPublisher.publish(providers, secret: self.pairing.currentSecret)
         }
         enabledProvidersObservation = store.$enabledProviderKinds.sink { [weak self] _ in
@@ -2539,6 +2617,7 @@ extension NSMenu {
         saveMenuBarAlertColor(settings.cautionColor, forKey: "menuBarCautionColor")
         saveMenuBarAlertColor(settings.warningColor, forKey: "menuBarWarningColor")
         saveMenuBarAlertColor(settings.criticalColor, forKey: "menuBarCriticalColor")
+        soundAlerter.settingsDidChange()
         updateStatusItem(store.providers)
         sidebarWindows.forEach { $0.contentView = makeHostingView() }
         popover?.contentViewController = NSHostingController(
@@ -2659,6 +2738,10 @@ extension NSMenu {
             keyEquivalent: "", symbolName: "menubar.rectangle")
         menuBarItem.state = showsMenuBar ? .on : .off
         menuBarItem.isEnabled = !(showsMenuBar && !showsNotch)
+        let soundItem = menu.addItem(
+            withTitle: String(localized: "Sound Alerts"), action: nil, keyEquivalent: "",
+            symbolName: "speaker.wave.2")
+        soundItem.submenu = buildSoundAlertsMenu()
         menu.addItem(.separator())
         menu.addItem(
             withTitle: String(localized: "Settings…"), action: #selector(openSettings), keyEquivalent: ",",
@@ -2677,6 +2760,56 @@ extension NSMenu {
                 updater
         }
         return menu
+    }
+
+    private func buildSoundAlertsMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.delegate = self
+        let onItem = menu.addItem(
+            withTitle: String(localized: "On"), action: #selector(soundAlertsOn), keyEquivalent: "")
+        onItem.target = self
+        let muteHourItem = menu.addItem(
+            withTitle: String(localized: "Mute 1 Hour"), action: #selector(muteSoundAlertsForOneHour),
+            keyEquivalent: "")
+        muteHourItem.target = self
+        let muteTomorrowItem = menu.addItem(
+            withTitle: String(localized: "Mute Until Tomorrow"),
+            action: #selector(muteSoundAlertsUntilTomorrow), keyEquivalent: "")
+        muteTomorrowItem.target = self
+        updateSoundAlertsMenuStates(menu)
+        return menu
+    }
+
+    private func updateSoundAlertsMenuStates(_ menu: NSMenu) {
+        let muted = soundAlerter.isMuted
+        for item in menu.items {
+            switch item.action {
+            case #selector(soundAlertsOn): item.state = muted ? .off : .on
+            case #selector(muteSoundAlertsForOneHour), #selector(muteSoundAlertsUntilTomorrow):
+                item.state = muted ? .on : .off
+            default: break
+            }
+        }
+    }
+
+    /// Refreshes the Sound Alerts submenu checkmarks right before the status item menu
+    /// opens, so mute state picked in Settings or the menu is always current.
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        updateSoundAlertsMenuStates(menu)
+    }
+
+    @objc private func soundAlertsOn() {
+        soundAlerter.clearMute()
+    }
+
+    @objc private func muteSoundAlertsForOneHour() {
+        soundAlerter.mute(untilInterval: Date().timeIntervalSince1970 + 60 * 60)
+    }
+
+    @objc private func muteSoundAlertsUntilTomorrow() {
+        let tomorrow = Calendar.current.date(
+            byAdding: .day, value: 1, to: Calendar.current.startOfDay(for: Date()))
+        soundAlerter.mute(untilInterval: (tomorrow ?? Date()).timeIntervalSince1970)
     }
 
     private func showNotchMenu(at windowPoint: NSPoint) {

--- a/apps/macos-native/Sources/Metria/MetriaApp.swift
+++ b/apps/macos-native/Sources/Metria/MetriaApp.swift
@@ -7,6 +7,7 @@ import MetriaCore
 import ServiceManagement
 import SwiftUI
 import UniformTypeIdentifiers
+import UserNotifications
 
 /// Stores the pairing master secret in the macOS Keychain. The secret never leaves the
 /// Mac in plaintext: the PWA only ever receives it via the QR code or 12-word phrase,
@@ -1691,6 +1692,14 @@ struct SettingsView: View {
     @AppStorage("soundAlertCriticalEnabled") private var soundAlertCriticalEnabled = true
     @AppStorage("soundAlertName") private var soundAlertName = "Glass"
     @AppStorage("soundAlertVolume") private var soundAlertVolume = 1.0
+    @AppStorage("usageNotificationsEnabled") private var usageNotificationsEnabled = false
+    @AppStorage("usageNotificationsCautionEnabled")
+    private var usageNotificationsCautionEnabled = true
+    @AppStorage("usageNotificationsWarningEnabled")
+    private var usageNotificationsWarningEnabled = true
+    @AppStorage("usageNotificationsCriticalEnabled")
+    private var usageNotificationsCriticalEnabled = true
+    @State private var notificationsBlocked = false
     @State private var cautionThreshold: Int
     @State private var warningThreshold: Int
     @State private var criticalThreshold: Int
@@ -1698,6 +1707,7 @@ struct SettingsView: View {
     @State private var warningColor: Color
     @State private var criticalColor: Color
     let onChangeMenuBarAlertSettings: (MenuBarAlertSettings) -> Void
+    let usageNotifier: UsageNotifier
     @State private var sidebarOpacity: Double
     let onChangeSidebarOpacity: (Double) -> Void
     @State private var launchAtLoginEnabled: Bool
@@ -1748,6 +1758,7 @@ struct SettingsView: View {
         onChangeMenuBarProviderNames: @escaping (Bool) -> Void,
         menuBarAlertSettings: MenuBarAlertSettings,
         onChangeMenuBarAlertSettings: @escaping (MenuBarAlertSettings) -> Void,
+        usageNotifier: UsageNotifier,
         sidebarOpacity: Double,
         onChangeSidebarOpacity: @escaping (Double) -> Void,
         launchAtLoginEnabled: Bool,
@@ -1791,6 +1802,7 @@ struct SettingsView: View {
         _warningColor = State(initialValue: Color(nsColor: menuBarAlertSettings.warningColor))
         _criticalColor = State(initialValue: Color(nsColor: menuBarAlertSettings.criticalColor))
         self.onChangeMenuBarAlertSettings = onChangeMenuBarAlertSettings
+        self.usageNotifier = usageNotifier
         _sidebarOpacity = State(initialValue: sidebarOpacity)
         self.onChangeSidebarOpacity = onChangeSidebarOpacity
         _launchAtLoginEnabled = State(initialValue: launchAtLoginEnabled)
@@ -2051,6 +2063,25 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Notifications") {
+                Toggle(
+                    "Show notifications when crossing thresholds",
+                    isOn: $usageNotificationsEnabled
+                )
+                .onChange(of: usageNotificationsEnabled) { enabled in
+                    Task { await refreshNotificationAuthorization(requestingIfNeeded: enabled) }
+                }
+                .task { await refreshNotificationAuthorization(requestingIfNeeded: false) }
+                notificationLevelControls
+                    .disabled(!usageNotificationsEnabled)
+                if notificationsBlocked {
+                    Text("Notifications are blocked for Metria in System Settings.")
+                        .foregroundStyle(.secondary)
+                }
+                Text("Notifications follow the system Focus and Do Not Disturb state.")
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Monitor") {
                 Picker(
                     "Monitor", selection: Binding(get: { notchScreenID }, set: onSelectNotchScreen)
@@ -2221,6 +2252,39 @@ struct SettingsView: View {
             UsageSoundAlerter.importCustomSound(from: url)
         else { return }
         soundAlertName = UsageSoundAlerter.customName
+    }
+
+    private var notificationLevelControls: some View {
+        Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+            notificationLevelControl(
+                label: String(localized: "Caution"), isOn: $usageNotificationsCautionEnabled)
+            notificationLevelControl(
+                label: String(localized: "Warning"), isOn: $usageNotificationsWarningEnabled)
+            notificationLevelControl(
+                label: String(localized: "Critical"), isOn: $usageNotificationsCriticalEnabled)
+        }
+    }
+
+    private func notificationLevelControl(label: String, isOn: Binding<Bool>) -> some View {
+        GridRow {
+            Text(label)
+            Toggle("\(label) notifications", isOn: isOn)
+                .labelsHidden()
+        }
+    }
+
+    /// Requests permission the first time the feature is switched on and mirrors a denial
+    /// from System Settings back into the toggle and the hint text.
+    @MainActor
+    private func refreshNotificationAuthorization(requestingIfNeeded: Bool) async {
+        if requestingIfNeeded {
+            await usageNotifier.requestAuthorizationIfNeeded()
+        }
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        notificationsBlocked = settings.authorizationStatus == .denied
+        if notificationsBlocked {
+            usageNotificationsEnabled = false
+        }
     }
 
     /// A small colored status dot shown right after the provider name: green when connected
@@ -2504,6 +2568,7 @@ extension NSMenu {
     private let updater = AppUpdater()
     private let localPWAServer = LocalPWAServer()
     let soundAlerter = UsageSoundAlerter()
+    let usageNotifier = UsageNotifier()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         migrateDisplayModeIfNeeded()
@@ -2525,6 +2590,7 @@ extension NSMenu {
             self?.updateStatusItem(providers)
             guard let self else { return }
             self.soundAlerter.process(providers)
+            self.usageNotifier.process(providers)
             self.ntfyPublisher.publish(providers, secret: self.pairing.currentSecret)
         }
         enabledProvidersObservation = store.$enabledProviderKinds.sink { [weak self] _ in
@@ -2618,6 +2684,7 @@ extension NSMenu {
         saveMenuBarAlertColor(settings.warningColor, forKey: "menuBarWarningColor")
         saveMenuBarAlertColor(settings.criticalColor, forKey: "menuBarCriticalColor")
         soundAlerter.settingsDidChange()
+        usageNotifier.settingsDidChange()
         updateStatusItem(store.providers)
         sidebarWindows.forEach { $0.contentView = makeHostingView() }
         popover?.contentViewController = NSHostingController(
@@ -3697,6 +3764,7 @@ extension NSMenu {
                 onChangeMenuBarAlertSettings: { [weak self] settings in
                     self?.setMenuBarAlertSettings(settings)
                 },
+                usageNotifier: usageNotifier,
                 sidebarOpacity: sidebarOpacity,
                 onChangeSidebarOpacity: { [weak self] opacity in self?.setSidebarOpacity(opacity) },
                 launchAtLoginEnabled: LaunchAtLoginManager.isEnabled,

--- a/apps/macos-native/Sources/Metria/MetriaApp.swift
+++ b/apps/macos-native/Sources/Metria/MetriaApp.swift
@@ -2766,7 +2766,7 @@ extension NSMenu {
         let menu = NSMenu()
         menu.delegate = self
         let onItem = menu.addItem(
-            withTitle: String(localized: "On"), action: #selector(soundAlertsOn), keyEquivalent: "")
+            withTitle: String(localized: "Unmuted"), action: #selector(soundAlertsOn), keyEquivalent: "")
         onItem.target = self
         let muteHourItem = menu.addItem(
             withTitle: String(localized: "Mute 1 Hour"), action: #selector(muteSoundAlertsForOneHour),
@@ -2781,12 +2781,18 @@ extension NSMenu {
     }
 
     private func updateSoundAlertsMenuStates(_ menu: NSMenu) {
+        // With the master switch off nothing here can produce sound, so no row may claim
+        // to be active: disable all of them and clear every checkmark.
+        let enabled = soundAlerter.isEnabled
         let muted = soundAlerter.isMuted
         for item in menu.items {
             switch item.action {
-            case #selector(soundAlertsOn): item.state = muted ? .off : .on
+            case #selector(soundAlertsOn):
+                item.state = enabled && !muted ? .on : .off
+                item.isEnabled = enabled
             case #selector(muteSoundAlertsForOneHour), #selector(muteSoundAlertsUntilTomorrow):
-                item.state = muted ? .on : .off
+                item.state = enabled && muted ? .on : .off
+                item.isEnabled = enabled
             default: break
             }
         }

--- a/apps/macos-native/Sources/Metria/ThresholdCrossingTracker.swift
+++ b/apps/macos-native/Sources/Metria/ThresholdCrossingTracker.swift
@@ -1,0 +1,95 @@
+import Foundation
+import MetriaCore
+
+/// Detects upward crossings of the menu bar alert thresholds between refresh ticks. Both
+/// the sound alerter and the usage notifications consume this one source of truth so
+/// their firing semantics cannot drift apart.
+///
+/// Thresholds come from the shared menu bar alert keys ("menuBarCautionThreshold",
+/// "menuBarWarningThreshold", "menuBarCriticalThreshold") with the same fallbacks as
+/// `MenuBarAlertSettings.default`.
+@MainActor
+final class ThresholdCrossingTracker {
+    /// One upward threshold crossing, ready to be delivered by a consumer.
+    struct Crossing: Equatable {
+        let kind: ProviderKind
+        let level: Level
+        let threshold: Int
+    }
+
+    enum Level: Int, CaseIterable {
+        case caution
+        case warning
+        case critical
+
+        var thresholdKey: String {
+            switch self {
+            case .caution: return "menuBarCautionThreshold"
+            case .warning: return "menuBarWarningThreshold"
+            case .critical: return "menuBarCriticalThreshold"
+            }
+        }
+
+        var fallbackThreshold: Int {
+            switch self {
+            case .caution: return MenuBarAlertSettings.default.cautionThreshold
+            case .warning: return MenuBarAlertSettings.default.warningThreshold
+            case .critical: return MenuBarAlertSettings.default.criticalThreshold
+            }
+        }
+
+        var threshold: Double {
+            Double(UserDefaults.standard.object(forKey: thresholdKey) as? Int ?? fallbackThreshold)
+        }
+    }
+
+    /// Provider + level pair that has already announced itself; cleared when the percent
+    /// falls back below that level's threshold, so a window reset can alert again.
+    private struct FiredKey: Hashable {
+        let kind: ProviderKind
+        let level: Level
+    }
+
+    private var lastPercent: [ProviderKind: Double] = [:]
+    private var fired: Set<FiredKey> = []
+
+    /// Called on every `UsageStore.providers` publish. The first sighting of a provider
+    /// only records a baseline. An upward crossing emits a `Crossing` once per provider
+    /// and level until the percent falls back below that level's threshold (which re-arms
+    /// it) or `reset()` is called. A provider losing its percent clears its baseline.
+    func update(_ providers: [ProviderUsage]) -> [Crossing] {
+        var crossings: [Crossing] = []
+        var current: [ProviderKind: Double] = [:]
+        for provider in providers {
+            guard let percent = provider.primary?.percent else {
+                lastPercent.removeValue(forKey: provider.kind)
+                continue
+            }
+            current[provider.kind] = percent
+            // A provider never seen before is baseline only: never alert on arrival.
+            guard let previous = lastPercent[provider.kind] else { continue }
+            for level in Level.allCases {
+                let key = FiredKey(kind: provider.kind, level: level)
+                if previous < level.threshold && percent >= level.threshold {
+                    if !fired.contains(key) {
+                        fired.insert(key)
+                        crossings.append(
+                            Crossing(
+                                kind: provider.kind, level: level,
+                                threshold: Int(level.threshold)))
+                    }
+                } else if previous >= level.threshold && percent < level.threshold {
+                    // Re-arm: the level may fire again on the next upward crossing.
+                    fired.remove(key)
+                }
+            }
+        }
+        lastPercent = current
+        return crossings
+    }
+
+    /// Clears every fired marker, e.g. after thresholds changed in Settings.
+    func reset() {
+        fired.removeAll()
+    }
+}

--- a/apps/macos-native/Sources/Metria/UsageNotifier.swift
+++ b/apps/macos-native/Sources/Metria/UsageNotifier.swift
@@ -1,0 +1,117 @@
+import Foundation
+import MetriaCore
+import UserNotifications
+
+/// Posts a macOS notification once when a provider's usage percent crosses one of the
+/// menu bar alert thresholds upward between refresh ticks.
+///
+/// Unlike the sound alerter, notifications ignore the manual sound mute and the
+/// login-session activity on purpose: Focus / Do Not Disturb filtering is macOS's job,
+/// and that awareness is the reason this feature exists. Locked-screen banner behavior
+/// is the system's too. Crossings seen while the feature or a level is switched off are
+/// discarded with no deferral.
+///
+/// UserDefaults keys read and written here (the Settings notifications block shares them):
+/// - "usageNotificationsEnabled" (Bool, default `false`): master switch.
+/// - "usageNotificationsCautionEnabled" / "usageNotificationsWarningEnabled" /
+///   "usageNotificationsCriticalEnabled" (Bool, default `true`): per-level switches.
+///
+/// Thresholds come from the shared menu bar alert keys ("menuBarCautionThreshold",
+/// "menuBarWarningThreshold", "menuBarCriticalThreshold") with the same fallbacks as
+/// `MenuBarAlertSettings.default`, read through `ThresholdCrossingTracker`.
+@MainActor
+final class UsageNotifier {
+    private static let enabledKey = "usageNotificationsEnabled"
+
+    private typealias Crossing = ThresholdCrossingTracker.Crossing
+
+    private let tracker = ThresholdCrossingTracker()
+    /// Refreshed from the notification center before every posting tick, so changes made
+    /// in System Settings stay honest.
+    private(set) var isAuthorized = false
+
+    /// Asks the user for notification permission when the feature is switched on. The
+    /// system only shows the prompt while the status is `.notDetermined`, so repeated
+    /// calls are safe — and they let a user recover a prompt they missed the first time
+    /// by toggling the feature off and on again.
+    func requestAuthorizationIfNeeded() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .notDetermined else { return }
+        _ = try? await center.requestAuthorization(options: [.alert, .sound])
+    }
+
+    /// Called when thresholds change in Settings so every level can fire again.
+    func settingsDidChange() {
+        tracker.reset()
+    }
+
+    /// Called on every `UsageStore.providers` publish. The first snapshot of a provider
+    /// only records a baseline; later snapshots post at most one notification per
+    /// provider, for its most severe upward crossing.
+    func process(_ providers: [ProviderUsage]) {
+        let crossings = tracker.update(providers).filter { $0.level.isNotificationEnabled }
+        guard isEnabled, !crossings.isEmpty else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            self.isAuthorized = settings.authorizationStatus == .authorized
+            guard self.isAuthorized else { return }
+            await self.post(crossings)
+        }
+    }
+
+    /// Whether the master switch in Settings is on.
+    private var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: Self.enabledKey) as? Bool ?? false
+    }
+
+    /// One notification per provider per tick; the most severe level wins when usage
+    /// jumps across several thresholds at once. Banners group per provider via
+    /// `threadIdentifier`, carry no sound (the sound alerts feature owns audio), and use
+    /// the default interruption level so Focus keeps working.
+    private func post(_ crossings: [Crossing]) async {
+        // Keep provider order; the most severe crossing wins within one provider.
+        var bestPerKind: [ProviderKind: Crossing] = [:]
+        var kindsInOrder: [ProviderKind] = []
+        for crossing in crossings {
+            if let current = bestPerKind[crossing.kind] {
+                if crossing.level.rawValue > current.level.rawValue {
+                    bestPerKind[crossing.kind] = crossing
+                }
+            } else {
+                bestPerKind[crossing.kind] = crossing
+                kindsInOrder.append(crossing.kind)
+            }
+        }
+        let center = UNUserNotificationCenter.current()
+        for kind in kindsInOrder {
+            guard let crossing = bestPerKind[kind] else { continue }
+            let content = UNMutableNotificationContent()
+            content.title = "Metria"
+            content.body = "\(kind.rawValue) reached \(crossing.threshold)% of its usage limit"
+            content.threadIdentifier = kind.rawValue
+            let request = UNNotificationRequest(
+                identifier: "metria.usage.\(kind.rawValue).\(crossing.level.rawValue)",
+                content: content,
+                trigger: nil)
+            try? await center.add(request)
+        }
+    }
+}
+
+/// Notification switches for the shared crossing levels. Threshold values live in
+/// `ThresholdCrossingTracker.Level`; only the per-level notification toggles belong here.
+private extension ThresholdCrossingTracker.Level {
+    var notificationEnabledKey: String {
+        switch self {
+        case .caution: return "usageNotificationsCautionEnabled"
+        case .warning: return "usageNotificationsWarningEnabled"
+        case .critical: return "usageNotificationsCriticalEnabled"
+        }
+    }
+
+    var isNotificationEnabled: Bool {
+        UserDefaults.standard.object(forKey: notificationEnabledKey) as? Bool ?? true
+    }
+}

--- a/apps/macos-native/Sources/Metria/UsageSoundAlerter.swift
+++ b/apps/macos-native/Sources/Metria/UsageSoundAlerter.swift
@@ -1,0 +1,236 @@
+import AppKit
+import Foundation
+import MetriaCore
+
+/// Plays a sound once when a provider's usage percent crosses one of the menu bar alert
+/// thresholds upward between refresh ticks.
+///
+/// UserDefaults keys read and written here (the Settings sound block shares them):
+/// - "soundAlertsEnabled" (Bool, default `false`): master switch.
+/// - "soundAlertCautionEnabled" / "soundAlertWarningEnabled" / "soundAlertCriticalEnabled"
+///   (Bool, default `true`): per-level switches.
+/// - "soundAlertName" (String, default `"Glass"`): one of "Glass", "Ping", "Submarine",
+///   or "custom" (a user-picked file copied into Application Support).
+/// - "soundAlertVolume" (Double, default `1.0`): playback volume, 0...1.
+/// - "soundAlertMutedUntil" (Double, default `0`): epoch seconds the mute lasts until;
+///   0 means not muted.
+///
+/// Thresholds come from the shared menu bar alert keys ("menuBarCautionThreshold",
+/// "menuBarWarningThreshold", "menuBarCriticalThreshold") with the same fallbacks as
+/// `MenuBarAlertSettings.default`.
+@MainActor
+final class UsageSoundAlerter {
+    static let systemSoundNames = ["Glass", "Ping", "Submarine"]
+    static let customName = "custom"
+
+    private static let enabledKey = "soundAlertsEnabled"
+    private static let soundNameKey = "soundAlertName"
+    private static let volumeKey = "soundAlertVolume"
+    private static let mutedUntilKey = "soundAlertMutedUntil"
+
+    /// Provider + level pair that has already announced itself; cleared when the percent
+    /// falls back below that level's threshold, so a window reset can alert again.
+    private struct FiredKey: Hashable {
+        let kind: ProviderKind
+        let level: Level
+    }
+
+    private enum Level: Int, CaseIterable {
+        case caution
+        case warning
+        case critical
+
+        var thresholdKey: String {
+            switch self {
+            case .caution: return "menuBarCautionThreshold"
+            case .warning: return "menuBarWarningThreshold"
+            case .critical: return "menuBarCriticalThreshold"
+            }
+        }
+
+        var fallbackThreshold: Int {
+            switch self {
+            case .caution: return MenuBarAlertSettings.default.cautionThreshold
+            case .warning: return MenuBarAlertSettings.default.warningThreshold
+            case .critical: return MenuBarAlertSettings.default.criticalThreshold
+            }
+        }
+
+        var enabledKey: String {
+            switch self {
+            case .caution: return "soundAlertCautionEnabled"
+            case .warning: return "soundAlertWarningEnabled"
+            case .critical: return "soundAlertCriticalEnabled"
+            }
+        }
+
+        var threshold: Double {
+            Double(UserDefaults.standard.object(forKey: thresholdKey) as? Int ?? fallbackThreshold)
+        }
+    }
+
+    private var lastPercent: [ProviderKind: Double] = [:]
+    private var fired: Set<FiredKey> = []
+    private var isSessionActive = true
+    private var sessionObservers: [NSObjectProtocol] = []
+    /// NSSound plays asynchronously; keep the last one alive until it finishes.
+    private var playingSound: NSSound?
+
+    init() {
+        let center = NSWorkspace.shared.notificationCenter
+        sessionObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.sessionDidResignActiveNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.isSessionActive = false }
+            })
+        sessionObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.sessionDidBecomeActiveNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.isSessionActive = true }
+            })
+    }
+
+    deinit {
+        for observer in sessionObservers {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+    }
+
+    /// Called on every `UsageStore.providers` publish. The first snapshot only records a
+    /// baseline; later snapshots fire at most one sound for the highest upward crossing.
+    func process(_ providers: [ProviderUsage]) {
+        var candidates: [(kind: ProviderKind, level: Level)] = []
+        var current: [ProviderKind: Double] = [:]
+        for provider in providers {
+            guard let percent = provider.primary?.percent else {
+                lastPercent.removeValue(forKey: provider.kind)
+                continue
+            }
+            current[provider.kind] = percent
+            // A provider never seen before is baseline only: never beep on arrival.
+            guard let previous = lastPercent[provider.kind] else { continue }
+            for level in Level.allCases {
+                let key = FiredKey(kind: provider.kind, level: level)
+                if previous < level.threshold && percent >= level.threshold {
+                    if !fired.contains(key) {
+                        fired.insert(key)
+                        candidates.append((provider.kind, level))
+                    }
+                } else if previous >= level.threshold && percent < level.threshold {
+                    // Re-arm: the level may fire again on the next upward crossing.
+                    fired.remove(key)
+                }
+            }
+        }
+        lastPercent = current
+
+        // At most one sound per refresh tick, for the most severe crossing.
+        let best = candidates.reduce(into: nil as (kind: ProviderKind, level: Level)?) { best, candidate in
+            if best == nil || candidate.level.rawValue > best!.level.rawValue { best = candidate }
+        }
+        guard let best else { return }
+        play(level: best.level)
+    }
+
+    /// Called when thresholds change in Settings so every level can fire again.
+    func settingsDidChange() {
+        fired.removeAll()
+    }
+
+    // MARK: Mute
+
+    var isMuted: Bool {
+        mutedUntil > Date().timeIntervalSince1970
+    }
+
+    func mute(untilInterval interval: Double) {
+        UserDefaults.standard.set(interval, forKey: Self.mutedUntilKey)
+    }
+
+    func clearMute() {
+        UserDefaults.standard.set(0, forKey: Self.mutedUntilKey)
+    }
+
+    private var mutedUntil: Double {
+        UserDefaults.standard.object(forKey: Self.mutedUntilKey) as? Double ?? 0
+    }
+
+    // MARK: Playback
+
+    private func play(level: Level) {
+        guard
+            UserDefaults.standard.object(forKey: Self.enabledKey) as? Bool ?? false,
+            UserDefaults.standard.object(forKey: level.enabledKey) as? Bool ?? true,
+            isSessionActive,
+            !isMuted,
+            let sound = Self.makeSound()
+        else { return }
+        sound.volume = Float(Self.configuredVolume)
+        sound.play()
+        playingSound = sound
+    }
+
+    /// Plays the currently selected sound (system or custom) at the configured volume,
+    /// for the Settings "Test" button.
+    static func playTestSound() {
+        guard let sound = makeSound() else { return }
+        sound.volume = Float(configuredVolume)
+        sound.play()
+        testSound = sound
+    }
+
+    /// Retained so async playback isn't cut short by deallocation.
+    private static var testSound: NSSound?
+
+    private static var configuredVolume: Double {
+        min(max(UserDefaults.standard.object(forKey: volumeKey) as? Double ?? 1.0, 0), 1)
+    }
+
+    /// The configured sound, or "Glass" when the custom file is missing or unreadable.
+    private static func makeSound() -> NSSound? {
+        let name = UserDefaults.standard.string(forKey: soundNameKey) ?? systemSoundNames[0]
+        if name == customName, let url = existingCustomSoundURL() {
+            return NSSound(contentsOf: url, byReference: false)
+        }
+        return NSSound(named: NSSound.Name(name == customName ? systemSoundNames[0] : name))
+            ?? NSSound(named: systemSoundNames[0])
+    }
+
+    // MARK: Custom sound file
+
+    static var customSoundDirectory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Metria/Sounds", isDirectory: true)
+    }
+
+    static func existingCustomSoundURL() -> URL? {
+        let contents = try? FileManager.default.contentsOfDirectory(
+            at: customSoundDirectory, includingPropertiesForKeys: nil)
+        return contents?.first { $0.lastPathComponent.hasPrefix("custom-alert.") }
+    }
+
+    /// Copies the picked file to Application Support as `custom-alert.<original extension>`,
+    /// replacing any previously imported custom sound. Returns success.
+    @discardableResult
+    static func importCustomSound(from url: URL) -> Bool {
+        do {
+            let directory = customSoundDirectory
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            for existing in try FileManager.default.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: nil)
+            where existing.lastPathComponent.hasPrefix("custom-alert.") {
+                try? FileManager.default.removeItem(at: existing)
+            }
+            let destination = directory.appendingPathComponent("custom-alert.\(url.pathExtension)")
+            // The cleanup loop above already removed same-named files; a leftover can only
+            // exist if that removal failed silently, so tolerate its absence here.
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.copyItem(at: url, to: destination)
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/apps/macos-native/Sources/Metria/UsageSoundAlerter.swift
+++ b/apps/macos-native/Sources/Metria/UsageSoundAlerter.swift
@@ -64,6 +64,10 @@ final class UsageSoundAlerter {
             }
         }
 
+        var isEnabled: Bool {
+            UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+        }
+
         var threshold: Double {
             Double(UserDefaults.standard.object(forKey: thresholdKey) as? Int ?? fallbackThreshold)
         }
@@ -71,6 +75,9 @@ final class UsageSoundAlerter {
 
     private var lastPercent: [ProviderKind: Double] = [:]
     private var fired: Set<FiredKey> = []
+    /// Crossings that happened while muted or with an inactive session, waiting for the
+    /// first tick on which they may sound.
+    private var pending: Set<FiredKey> = []
     private var isSessionActive = true
     private var sessionObservers: [NSObjectProtocol] = []
     /// NSSound plays asynchronously; keep the last one alive until it finishes.
@@ -100,6 +107,9 @@ final class UsageSoundAlerter {
 
     /// Called on every `UsageStore.providers` publish. The first snapshot only records a
     /// baseline; later snapshots fire at most one sound for the highest upward crossing.
+    /// Crossings seen while alerts are muted or the login session is inactive are deferred
+    /// and played on the first tick after the suppressor clears; crossings seen while the
+    /// feature or the level is disabled are discarded.
     func process(_ providers: [ProviderUsage]) {
         var candidates: [(kind: ProviderKind, level: Level)] = []
         var current: [ProviderKind: Double] = [:]
@@ -116,30 +126,57 @@ final class UsageSoundAlerter {
                 if previous < level.threshold && percent >= level.threshold {
                     if !fired.contains(key) {
                         fired.insert(key)
-                        candidates.append((provider.kind, level))
+                        if level.isEnabled { candidates.append((provider.kind, level)) }
                     }
                 } else if previous >= level.threshold && percent < level.threshold {
-                    // Re-arm: the level may fire again on the next upward crossing.
+                    // Re-arm: the level may fire again on the next upward crossing. A
+                    // deferred alert for this level is stale now — the reset itself told
+                    // that story — so drop it along with the fired marker.
                     fired.remove(key)
+                    pending.remove(key)
                 }
             }
         }
         lastPercent = current
 
+        guard isEnabled else {
+            pending.removeAll()
+            return
+        }
+
+        // Hold crossings that cannot sound yet instead of consuming them silently.
+        guard isSessionActive, !isMuted else {
+            for candidate in candidates {
+                pending.insert(FiredKey(kind: candidate.kind, level: candidate.level))
+            }
+            return
+        }
+
+        var deliverable = candidates
+        for key in pending { deliverable.append((key.kind, key.level)) }
+
         // At most one sound per refresh tick, for the most severe crossing.
-        let best = candidates.reduce(into: nil as (kind: ProviderKind, level: Level)?) { best, candidate in
+        let best = deliverable.reduce(into: nil as (kind: ProviderKind, level: Level)?) { best, candidate in
             if best == nil || candidate.level.rawValue > best!.level.rawValue { best = candidate }
         }
         guard let best else { return }
+        // One beep covers the whole suppressed batch.
+        pending.removeAll()
         play(level: best.level)
     }
 
     /// Called when thresholds change in Settings so every level can fire again.
     func settingsDidChange() {
         fired.removeAll()
+        pending.removeAll()
     }
 
     // MARK: Mute
+
+    /// Whether the master switch in Settings is on.
+    var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: Self.enabledKey) as? Bool ?? false
+    }
 
     var isMuted: Bool {
         mutedUntil > Date().timeIntervalSince1970

--- a/apps/macos-native/Sources/Metria/UsageSoundAlerter.swift
+++ b/apps/macos-native/Sources/Metria/UsageSoundAlerter.swift
@@ -15,9 +15,8 @@ import MetriaCore
 /// - "soundAlertMutedUntil" (Double, default `0`): epoch seconds the mute lasts until;
 ///   0 means not muted.
 ///
-/// Thresholds come from the shared menu bar alert keys ("menuBarCautionThreshold",
-/// "menuBarWarningThreshold", "menuBarCriticalThreshold") with the same fallbacks as
-/// `MenuBarAlertSettings.default`.
+/// Crossing detection and thresholds are shared with the notifications feature through
+/// `ThresholdCrossingTracker`; this class only owns playback and its suppressors.
 @MainActor
 final class UsageSoundAlerter {
     static let systemSoundNames = ["Glass", "Ping", "Submarine"]
@@ -28,53 +27,18 @@ final class UsageSoundAlerter {
     private static let volumeKey = "soundAlertVolume"
     private static let mutedUntilKey = "soundAlertMutedUntil"
 
-    /// Provider + level pair that has already announced itself; cleared when the percent
-    /// falls back below that level's threshold, so a window reset can alert again.
+    /// Provider + level pair used as the key for deferred sounds. The fired markers
+    /// themselves live in the tracker.
     private struct FiredKey: Hashable {
         let kind: ProviderKind
         let level: Level
     }
 
-    private enum Level: Int, CaseIterable {
-        case caution
-        case warning
-        case critical
+    /// The shared crossing levels. Thresholds live in `ThresholdCrossingTracker.Level`;
+    /// the per-level sound switches are added in the extension below.
+    private typealias Level = ThresholdCrossingTracker.Level
 
-        var thresholdKey: String {
-            switch self {
-            case .caution: return "menuBarCautionThreshold"
-            case .warning: return "menuBarWarningThreshold"
-            case .critical: return "menuBarCriticalThreshold"
-            }
-        }
-
-        var fallbackThreshold: Int {
-            switch self {
-            case .caution: return MenuBarAlertSettings.default.cautionThreshold
-            case .warning: return MenuBarAlertSettings.default.warningThreshold
-            case .critical: return MenuBarAlertSettings.default.criticalThreshold
-            }
-        }
-
-        var enabledKey: String {
-            switch self {
-            case .caution: return "soundAlertCautionEnabled"
-            case .warning: return "soundAlertWarningEnabled"
-            case .critical: return "soundAlertCriticalEnabled"
-            }
-        }
-
-        var isEnabled: Bool {
-            UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
-        }
-
-        var threshold: Double {
-            Double(UserDefaults.standard.object(forKey: thresholdKey) as? Int ?? fallbackThreshold)
-        }
-    }
-
-    private var lastPercent: [ProviderKind: Double] = [:]
-    private var fired: Set<FiredKey> = []
+    private let tracker = ThresholdCrossingTracker()
     /// Crossings that happened while muted or with an inactive session, waiting for the
     /// first tick on which they may sound.
     private var pending: Set<FiredKey> = []
@@ -112,32 +76,20 @@ final class UsageSoundAlerter {
     /// feature or the level is disabled are discarded.
     func process(_ providers: [ProviderUsage]) {
         var candidates: [(kind: ProviderKind, level: Level)] = []
-        var current: [ProviderKind: Double] = [:]
-        for provider in providers {
-            guard let percent = provider.primary?.percent else {
-                lastPercent.removeValue(forKey: provider.kind)
-                continue
-            }
-            current[provider.kind] = percent
-            // A provider never seen before is baseline only: never beep on arrival.
-            guard let previous = lastPercent[provider.kind] else { continue }
-            for level in Level.allCases {
-                let key = FiredKey(kind: provider.kind, level: level)
-                if previous < level.threshold && percent >= level.threshold {
-                    if !fired.contains(key) {
-                        fired.insert(key)
-                        if level.isEnabled { candidates.append((provider.kind, level)) }
-                    }
-                } else if previous >= level.threshold && percent < level.threshold {
-                    // Re-arm: the level may fire again on the next upward crossing. A
-                    // deferred alert for this level is stale now — the reset itself told
-                    // that story — so drop it along with the fired marker.
-                    fired.remove(key)
-                    pending.remove(key)
-                }
-            }
+        for crossing in tracker.update(providers) where crossing.level.isSoundEnabled {
+            candidates.append((crossing.kind, crossing.level))
         }
-        lastPercent = current
+        // The tracker re-arms a level when the percent falls back below its threshold; a
+        // deferred alert for that level is stale now — the reset itself told that story —
+        // so drop it too. A provider without a percent keeps its pending alert.
+        var currentPercents: [ProviderKind: Double] = [:]
+        for provider in providers {
+            if let percent = provider.primary?.percent { currentPercents[provider.kind] = percent }
+        }
+        pending = pending.filter { key in
+            guard let percent = currentPercents[key.kind] else { return true }
+            return percent >= key.level.threshold
+        }
 
         guard isEnabled else {
             pending.removeAll()
@@ -167,7 +119,7 @@ final class UsageSoundAlerter {
 
     /// Called when thresholds change in Settings so every level can fire again.
     func settingsDidChange() {
-        fired.removeAll()
+        tracker.reset()
         pending.removeAll()
     }
 
@@ -199,7 +151,7 @@ final class UsageSoundAlerter {
     private func play(level: Level) {
         guard
             UserDefaults.standard.object(forKey: Self.enabledKey) as? Bool ?? false,
-            UserDefaults.standard.object(forKey: level.enabledKey) as? Bool ?? true,
+            level.isSoundEnabled,
             isSessionActive,
             !isMuted,
             let sound = Self.makeSound()
@@ -269,5 +221,21 @@ final class UsageSoundAlerter {
         } catch {
             return false
         }
+    }
+}
+
+/// Sound switches for the shared crossing levels. Threshold values live in
+/// `ThresholdCrossingTracker.Level`; only the per-level sound toggles belong here.
+private extension ThresholdCrossingTracker.Level {
+    var soundEnabledKey: String {
+        switch self {
+        case .caution: return "soundAlertCautionEnabled"
+        case .warning: return "soundAlertWarningEnabled"
+        case .critical: return "soundAlertCriticalEnabled"
+        }
+    }
+
+    var isSoundEnabled: Bool {
+        UserDefaults.standard.object(forKey: soundEnabledKey) as? Bool ?? true
     }
 }


### PR DESCRIPTION
## Summary
- **Sound alerts**: plays a configurable system or custom sound once when a provider crosses a menu bar alert threshold upward between refresh ticks. Settings gains a Sound alerts section (master switch, per-level toggles, Glass/Ping/Submarine/custom picker with file import into Application Support, volume, test button); the status menu gains a Sound Alerts mute (unmuted / 1 hour / until tomorrow). Crossings seen while muted or with an inactive login session are deferred to the first tick after the suppressor clears; crossings while the feature or a level is off are discarded.
- **Native notifications**: DND-aware banners once per provider per crossing, grouped per provider, no attached sound, default interruption level (Focus suppression stays the system's job), ignoring the sound mute. Crossing detection is shared with sound alerts through a new `ThresholdCrossingTracker` so both features keep identical firing semantics. Permission is requested when the feature is enabled and re-requested if the prompt was missed.
- No `MetriaCore` changes (pairing surfaces untouched). `Package.swift` and the Xcode project list the new files.

## Verification
- `swift build` green; `xcodegen generate` run and committed (`UsageSoundAlerter`, `ThresholdCrossingTracker`, `UsageNotifier` present in the pbxproj).
- Local `package-macos.sh` build manually tested on macOS 26: sound on crossing, deferral through mute, custom sound import, volume, mute menu states, notification banner, permission prompt/recovery.
